### PR TITLE
Fix image name and add git commit name as tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+IMAGE_TAG := $(shell hack/image-tag)
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= weaveworks/cluster-api-existinginfra-controller:$(IMAGE_TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 

--- a/hack/image-tag
+++ b/hack/image-tag
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
+CURRENT_TAG=$(if TAG=$(git describe --tags --exact-match 2>/dev/null); then echo $TAG; else echo ""; fi)
+if test -z "$WORKING_SUFFIX" && test ! -z "$CURRENT_TAG" 
+then 
+   echo $CURRENT_TAG
+else 
+   BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+   
+   # Fix the object name prefix length to 8 characters to have it consistent across the system.
+   # See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength
+   echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short=8 HEAD)$WORKING_SUFFIX"
+fi


### PR DESCRIPTION
The name now looks like `weaveworks/cluster-api-existinginfra-controller:master-4208b1f9`

The `image-tag` script is copied from https://github.com/weaveworks/wksctl/blob/3fb084a7f797495908ec01e56444986e76d31861/tools/image-tag