### PR TITLE
Only report new Go lint errors

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -16,3 +16,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.30
+          args: --new-from-rev dc07dd97bb2688ad31c399a8651e386ee052146b

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -235,7 +235,7 @@ func fetchOSID(sshClient plan.Runner) (string, error) {
 	return strings.Trim(matches[idxOSID], ` "`), nil
 }
 
-// CreatePlan generates a plan from a plan builder
+// CreatePlan generates a plan from a plan builder.
 func CreatePlan(b *plan.Builder) (*plan.Plan, error) {
 	p, err := b.Plan()
 	if err != nil {

--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -23,6 +23,11 @@ const (
 	ConfigDestDir = "/etc/pki/weaveworks/wksctl"
 )
 
+var (
+	ErrNoConfigData = errors.New("no config data for filespec")
+	ErrUnknownOS    = errors.New("unknown operating system")
+)
+
 // OS represents an operating system and exposes the operations required to
 // install Kubernetes on a machine setup with that OS.
 type OS struct {
@@ -61,7 +66,7 @@ func CreateConfigFileResourcesFromConfigMaps(fileSpecs []existinginfrav1.FileSpe
 		// if not in Data, check BinaryData
 		binaryContents, ok := configMaps[source.ConfigMap].BinaryData[source.Key]
 		if !ok {
-			return nil, fmt.Errorf("No config data for filespec: %v", file)
+			return nil, fmt.Errorf("%q: %w", file, ErrNoConfigData)
 		}
 		fileResource.Content = string(binaryContents)
 		fileResources[idx] = fileResource
@@ -207,7 +212,7 @@ func Identify(sshClient plan.Runner) (*OS, error) {
 	case Ubuntu:
 		return &OS{Name: osID, Runner: &sudo.Runner{Runner: sshClient}, PkgType: resource.PkgTypeDeb}, nil
 	default:
-		return nil, fmt.Errorf("unknown operating system %q", osID)
+		return nil, fmt.Errorf("%q: %w", osID, ErrUnknownOS)
 	}
 }
 

--- a/pkg/plan/runners/ssh/ssh.go
+++ b/pkg/plan/runners/ssh/ssh.go
@@ -16,10 +16,10 @@ import (
 // ClientParams groups inputs to build a client object.
 type ClientParams struct {
 	User           string
-	Host           string
-	Port           uint16
 	PrivateKeyPath string
 	PrivateKey     []byte
+	Host           string
+	Port           uint16
 	PrintOutputs   bool
 }
 

--- a/pkg/plan/runners/ssh/ssh.go
+++ b/pkg/plan/runners/ssh/ssh.go
@@ -76,7 +76,7 @@ func (c *Client) RunCommand(command string, stdin io.Reader) (string, error) {
 	})
 }
 
-// Handle output and command completion for a remote shell
+// Handle output and command completion for a remote shell.
 func (c *Client) handleSessionIO(action func(*ssh.Session) error) (string, error) {
 	session, err := c.client.NewSession()
 	if err != nil {

--- a/pkg/utilities/version/version.go
+++ b/pkg/utilities/version/version.go
@@ -6,11 +6,11 @@ import (
 )
 
 func Jump(nodeVersion, machineVersion string) (bool, error) {
-	nodemajor, nodeminor, _, err := parseVersion(nodeVersion)
+	nodemajor, nodeminor, err := parseVersion(nodeVersion)
 	if err != nil {
 		return false, err
 	}
-	machinemajor, machineminor, _, err := parseVersion(machineVersion)
+	machinemajor, machineminor, err := parseVersion(machineVersion)
 	if err != nil {
 		return false, err
 	}
@@ -29,10 +29,10 @@ func LessThan(s1, s2 string) (bool, error) {
 	return v1.LessThan(v2), nil
 }
 
-func parseVersion(s string) (int, int, int, error) {
+func parseVersion(s string) (int, int, error) {
 	v, err := version.ParseSemantic(s)
 	if err != nil {
-		return -1, -1, -1, errors.Wrap(err, "invalid kubernetes version")
+		return -1, -1, errors.Wrap(err, "invalid kubernetes version")
 	}
-	return int(v.Major()), int(v.Minor()), int(v.Patch()), nil
+	return int(v.Major()), int(v.Minor()), nil
 }


### PR DESCRIPTION
Since we have a lot of lint errors, and an issue #4 to fix them up, it is unhelpful to fail every new check with the same old issues.

This change restricts golangci-lint to tell us only about issues added after it was configured into this repo.