### PR TITLE
Set providerID on ExistingInfraMachine; change name to existingInfra

### DIFF
--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -188,7 +188,7 @@ func (a *ExistingInfraMachineReconciler) create(ctx context.Context, installer *
 		return err
 	}
 	// CAPI machine controller requires providerID
-	eim.Spec.ProviderID = node.Spec.ProviderID
+	eim.Spec.ProviderID = generateProviderID(node.Name)
 	eim.Status.Ready = true
 	a.recordEvent(machine, corev1.EventTypeNormal, "Create", "created machine %s", machine.Name)
 	return nil
@@ -480,7 +480,7 @@ func (a *ExistingInfraMachineReconciler) update(ctx context.Context, c *existing
 		return err
 	}
 	// CAPI machine controller requires providerID
-	eim.Spec.ProviderID = node.Spec.ProviderID
+	eim.Spec.ProviderID = generateProviderID(node.Name)
 	eim.Status.Ready = true
 
 	a.recordEvent(machine, corev1.EventTypeNormal, "Update", "updated machine %s", machine.Name)
@@ -791,10 +791,14 @@ func (a *ExistingInfraMachineReconciler) setNodeAnnotation(ctx context.Context, 
 	return nil
 }
 
+func generateProviderID(nodeName string) string {
+	return "wks://" + nodeName
+}
+
 // Note: does not modify the Node passed in
 func (a *ExistingInfraMachineReconciler) setNodeProviderIDIfNecessary(ctx context.Context, node *corev1.Node) error {
 	err := a.modifyNode(ctx, node.Name, func(node *corev1.Node) {
-		node.Spec.ProviderID = "wks://" + node.Name
+		node.Spec.ProviderID = generateProviderID(node.Name)
 	})
 	if err != nil {
 		return gerrors.Wrapf(err, "Failed to set providerID on node: %s", node.Name)

--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -824,14 +824,14 @@ func (a *ExistingInfraMachineReconciler) modifyNode(ctx context.Context, nodeNam
 		updater(&result)
 		updateErr := a.Client.Update(ctx, &result)
 		if updateErr != nil {
-			contextLog.Errorf("failed attempt to update node annotation: %v", updateErr)
+			contextLog.Errorf("failed attempt to update node: %v", updateErr)
 			return updateErr
 		}
 		return nil
 	})
 	if retryErr != nil {
-		contextLog.Errorf("failed to update node annotation: %v", retryErr)
-		return gerrors.Wrapf(retryErr, "Could not mark node %s as updated", nodeName)
+		contextLog.Errorf("failed to update node: %v", retryErr)
+		return gerrors.Wrapf(retryErr, "could not update node %s", nodeName)
 	}
 	return nil
 }

--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -797,6 +797,9 @@ func generateProviderID(nodeName string) string {
 
 // Note: does not modify the Node passed in
 func (a *ExistingInfraMachineReconciler) setNodeProviderIDIfNecessary(ctx context.Context, node *corev1.Node) error {
+	if node.Spec.ProviderID != "" {
+		return nil
+	}
 	err := a.modifyNode(ctx, node.Name, func(node *corev1.Node) {
 		node.Spec.ProviderID = generateProviderID(node.Name)
 	})

--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -792,7 +792,7 @@ func (a *ExistingInfraMachineReconciler) setNodeAnnotation(ctx context.Context, 
 }
 
 func generateProviderID(nodeName string) string {
-	return "wks://" + nodeName
+	return "existingInfra://" + nodeName
 }
 
 // Note: does not modify the Node passed in


### PR DESCRIPTION
The controller called `setNodeProviderIDIfNecessary()` then used the `ProviderID` value inside the `Node`, however `setNodeProviderIDIfNecessary()` only sets the back-end state: it does not update the in-memory copy which was still a blank string.  This prevented the core CAPI controller from seeing the machine as ready.

To clarify what is happening I changed all similar `setNodeXXX` functions to take the node name only.

Change the string contents from "wks:" to "existingInfra", in line with the split of this repo from wksctl.

Also fixed a couple of error and log messages that didn't describe what was happening, and check if the string is blank before setting it (this matches the 'IfNecessary' part of the name).