### PR TITLE
Fix CircleCI release failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,6 @@ workflows:
             tags:
               only: /.*/
       - unit-tests: {}
-      - release:
-          requires:
-            - build
-            - unit-tests
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
 
 jobs:
   build:
@@ -67,9 +58,3 @@ jobs:
           command: |
             go version
             make test
-
-  release:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: curl -sL https://git.io/goreleaser | IMAGE_TAG=`tools/image-tag` bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install kubectl
-          command: |
-            curl -L $KUBECTL_URL -o kubectl.tar.gz
-            echo "$KUBECTL_CHECKSUM kubectl.tar.gz" | sha256sum -c
-            tar xvzf kubectl.tar.gz --strip-components=3
-            sudo mv kubectl /usr/local/bin
-
-      - run:
           name: Run unit tests
           command: |
             go version


### PR DESCRIPTION
By simply removing the 'release' step from CircleCI config.

Example failure: https://app.circleci.com/pipelines/github/weaveworks/cluster-api-provider-existinginfra/42/workflows/a3879d55-9794-4dde-9caa-3debc8a4f70b/jobs/82

The output of this repo is a docker image, which is pushed from the build step, so we don't need a release step.

While I'm here, don't install kubectl for unit tests - no unit test in this repo uses kubectl.
