### PR TITLE
[WKP-1475] Check if node can be updated early

### DIFF
--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -444,6 +444,12 @@ func (a *ExistingInfraMachineReconciler) update(ctx context.Context, c *existing
 	if err = a.setNodeProviderIDIfNecessary(ctx, node); err != nil {
 		return err
 	}
+	isMaster := isMaster(node)
+	if isMaster {
+		if err := a.prepareForMasterUpdate(ctx, node); err != nil {
+			return err
+		}
+	}
 	nodePlan, err := a.getNodePlan(ctx, c, machine, a.getMachineAddress(eim), installer)
 	if err != nil {
 		return gerrors.Wrapf(err, "Failed to get node plan for machine %s", machine.Name)
@@ -474,12 +480,7 @@ func (a *ExistingInfraMachineReconciler) update(ctx context.Context, c *existing
 	}
 
 	contextLog.Infof("........................NEW UPDATE FOR: %s...........................", machine.Name)
-	isMaster := isMaster(node)
-	if isMaster {
-		if err := a.prepareForMasterUpdate(ctx, node); err != nil {
-			return err
-		}
-	}
+
 	upOrDowngrade := isUpOrDowngrade(machine, node)
 	contextLog.Infof("Is master: %t, is up or downgrade: %t", isMaster, upOrDowngrade)
 	if upOrDowngrade {


### PR DESCRIPTION
This makes the reconciliation loop faster and solves the issue of
generating multiple bootstrap-tokens, even if the update could not be applied.

The issue was observed when trying to update a cp node where its bootstrap-token has expired, as the `getNodePlan()` function will generate a token in every loop.