### PR TITLE
Allow wks-controller to get/list/watch configmaps

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,3 +66,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Appends in the clusterrole of `wks-controller` reader permissions for configmaps.