### PR TITLE
Change calculation of SetSELinuxPermissive flag

### DIFF
--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -253,7 +253,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			},
 
 			wantUseIPTables:          true,
-			wantSetSELinuxPermissive: false,
+			wantSetSELinuxPermissive: true,
 			wantDisableSwap:          true,
 			wantLockYUMPkgs:          false,
 			wantNamespace:            "foo",

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -39,7 +39,7 @@ func GetEnvSpecificConfig(pkgType resource.PkgType, namespace string, cloudProvi
 	if err != nil {
 		return nil, errors.Wrap(err, "NewOS")
 	}
-	seLinuxStatus, seLinuxMode, err := osres.GetSELinuxStatus()
+	seLinuxStatus, _, err := osres.GetSELinuxStatus()
 	if err != nil {
 		return nil, errors.Wrap(err, "GetSELinuxStatus")
 	}
@@ -67,7 +67,7 @@ func GetEnvSpecificConfig(pkgType resource.PkgType, namespace string, cloudProvi
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,
 		SELinuxInstalled:      seLinuxStatus.IsInstalled(),
-		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && seLinuxMode.IsEnforcing(), // if it's enforcing, set to permissive
+		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled(), // if selinux is installed always try to set to permissive
 		LockYUMPkgs:           pkgType == resource.PkgTypeRPM,
 		DisableSwap:           !inContainerVM,
 		IgnorePreflightErrors: ignorePreflightErrors,


### PR DESCRIPTION
This change will not check for the current mode of selinux, when calculating if it should be set to permissive, as this causes a diff in the node plan as soon as it is set to permissive the first time.