### PR TITLE
Fixes kubeadm cli after 1.18 removed "config" command

### DIFF
--- a/pkg/plan/recipe/upgrade_plans.go
+++ b/pkg/plan/recipe/upgrade_plans.go
@@ -88,7 +88,9 @@ func BuildUpgradePlan(pkgType resource.PkgType, k8sVersion string, ntype NodeTyp
 	case Worker:
 		b.AddResource(
 			"upgrade:node-kubeadm-upgrade",
-			&resource.Run{Script: object.String(fmt.Sprintf("kubeadm upgrade node config --kubelet-version %s", k8sVersion))},
+			// From kubeadm upgrade node phase kubelet-config --help
+			// > kubeadm uses the KuberneteVersion field in the kubeadm-config ConfigMap to determine what the _desired_ kubelet version is.
+			&resource.Run{Script: object.String("kubeadm upgrade node phase kubelet-config")},
 			plan.DependOn("upgrade:node-install-kubeadm"))
 	}
 


### PR DESCRIPTION
In reaction to:
- kubeadm: remove 'kubeadm upgrade node config' command when v1.18 is
  released #87975:
  https://github.com/kubernetes/kubernetes/pull/87975

The version is now pulled from a configmap. Looking at a stalled upgrade
it looks good:

$ kubectl get configmap -n kube-system kubeadm-config -oyaml | \
  grep kubernetesVersion
    kubernetesVersion: v1.18.10