### PR TITLE
Pre-update image tag to v0.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,15 +32,6 @@ workflows:
       - integration-tests:
           requires:
             - build
-      - release:
-          requires:
-            - build
-            - unit-tests
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
 
 jobs:
   build:

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "v0.0.7"
+const ImageTag = "v0.0.8"

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "track-cluster-spec-modifications-and-repave-machines-when-they-change-862c0699"
+const ImageTag = "v0.0.7"


### PR DESCRIPTION
We're are going to try for a self-referential `v0.0.8` tag. Once this PR is merged we'll re-tag / release capei as `v0.0.8` and see what happens.