### PR TITLE
Repave every machine when the cluster changes

### DIFF
--- a/pkg/apis/wksprovider/machine/os/os.go
+++ b/pkg/apis/wksprovider/machine/os/os.go
@@ -422,7 +422,8 @@ func CreateClusterConfigMap(eic *existinginfrav1.ExistingInfraCluster, namespace
 	if err != nil {
 		return nil, err
 	}
-	configMap.Data["spec"] = fmt.Sprintf("%v", sha256.Sum256(specBytes))
+	hash := sha256.Sum256(specBytes)
+	configMap.Data["spec"] = base64.StdEncoding.EncodeToString(hash[:])
 
 	machineList := []string{seedNodeIP}
 	machineListBytes, err := json.Marshal(machineList)

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "v0.0.9"
+const ImageTag = "fix-argument-updating-when-run-from-wks-7ef538a8-WIP"

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "fix-argument-updating-when-run-from-wks-7ef538a8-WIP"
+const ImageTag = "v0.0.9"


### PR DESCRIPTION
Don't try to keep track of which ones have been seen... Now whenever a cluster object spec changes, we repave all existing nodes.