### PR TITLE
[WKP-1550] Fix selinux permissive undo script, add back selinuxmode check

### DIFF
--- a/controllers/cluster.weave.works/existinginframachine_controller.go
+++ b/controllers/cluster.weave.works/existinginframachine_controller.go
@@ -559,6 +559,17 @@ func (a *ExistingInfraMachineReconciler) update(ctx context.Context, c *existing
 		return a.kubeadmUpOrDowngrade(ctx, c, machine, eim, node, installer, version, planJSON, recipe.Worker)
 	}
 
+	isOriginal, err := a.isOriginalMaster(ctx, node)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Is original control plane node: ", isOriginal)
+	log.Info("ControlPlaneEndpoint: ", c.Spec.ControlPlaneEndpoint)
+	if isOriginal && c.Spec.ControlPlaneEndpoint == "" {
+		return errors.New("cannot perform update of original control plane node without a control plane load balacer")
+	}
+
 	if err = a.performActualUpdate(ctx, installer, machine, node, nodePlan, c); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,64 +3,64 @@ module github.com/weaveworks/cluster-api-provider-existinginfra
 go 1.13
 
 require (
-    github.com/bitnami-labs/sealed-secrets v0.12.5
-    github.com/blang/semver v3.5.1+incompatible
-    github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8
-    github.com/chanwit/plandiff v1.0.0
-    github.com/fatih/structs v1.1.0
-    github.com/ghodss/yaml v1.0.0
-    github.com/go-logr/logr v0.1.0
-    github.com/oleiade/reflections v1.0.0 // indirect
-    github.com/onsi/ginkgo v1.12.1
-    github.com/onsi/gomega v1.10.1
-    github.com/pkg/errors v0.9.1
-    github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
-    github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
-    github.com/sirupsen/logrus v1.6.0
-    github.com/spf13/pflag v1.0.5
-    github.com/stretchr/testify v1.6.1
-    github.com/tj/assert v0.0.3
-    github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e // indirect
-    github.com/weaveworks/libgitops v0.0.2
-    golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
-    golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-    gopkg.in/oleiade/reflections.v1 v1.0.0
-    gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
-    k8s.io/api v0.18.6
-    k8s.io/apimachinery v0.18.8
-    k8s.io/client-go v0.18.6
-    k8s.io/cluster-bootstrap v0.18.6
-    k8s.io/kube-proxy v0.0.0
-    k8s.io/kubectl v0.18.6
-    k8s.io/kubernetes v1.18.6
-    k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
-    sigs.k8s.io/cluster-api v0.3.6
-    sigs.k8s.io/controller-runtime v0.6.0
-    sigs.k8s.io/kind v0.9.0 // indirect
-    sigs.k8s.io/kustomize/kyaml v0.4.2
-    sigs.k8s.io/yaml v1.2.0
+	github.com/bitnami-labs/sealed-secrets v0.12.5
+	github.com/blang/semver v3.5.1+incompatible
+	github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8
+	github.com/chanwit/plandiff v1.0.0
+	github.com/fatih/structs v1.1.0
+	github.com/ghodss/yaml v1.0.0
+	github.com/go-logr/logr v0.1.0
+	github.com/oleiade/reflections v1.0.0 // indirect
+	github.com/onsi/ginkgo v1.12.1
+	github.com/onsi/gomega v1.10.1
+	github.com/pkg/errors v0.9.1
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
+	github.com/sirupsen/logrus v1.6.0
+	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.6.1
+	github.com/tj/assert v0.0.3
+	github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e // indirect
+	github.com/weaveworks/libgitops v0.0.2
+	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	gopkg.in/oleiade/reflections.v1 v1.0.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+	k8s.io/api v0.18.6
+	k8s.io/apimachinery v0.18.8
+	k8s.io/client-go v0.18.6
+	k8s.io/cluster-bootstrap v0.18.6
+	k8s.io/kube-proxy v0.0.0
+	k8s.io/kubectl v0.18.6
+	k8s.io/kubernetes v1.18.6
+	k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
+	sigs.k8s.io/cluster-api v0.3.6
+	sigs.k8s.io/controller-runtime v0.6.0
+	sigs.k8s.io/kind v0.9.0 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.4.2
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
-    k8s.io/api => k8s.io/api v0.18.6
-    k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6
-    k8s.io/apimachinery => k8s.io/apimachinery v0.18.6
-    k8s.io/apiserver => k8s.io/apiserver v0.18.6
-    k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.6
-    k8s.io/client-go => k8s.io/client-go v0.18.6
-    k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.6
-    k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.6
-    k8s.io/code-generator => k8s.io/code-generator v0.18.6
-    k8s.io/component-base => k8s.io/component-base v0.18.6
-    k8s.io/cri-api => k8s.io/cri-api v0.18.6
-    k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.6
-    k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.6
-    k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.6
-    k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.6
-    k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.6
-    k8s.io/kubectl => k8s.io/kubectl v0.18.6
-    k8s.io/kubelet => k8s.io/kubelet v0.18.6
-    k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.6
-    k8s.io/metrics => k8s.io/metrics v0.18.6
-    k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.6
+	k8s.io/api => k8s.io/api v0.18.6
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6
+	k8s.io/apimachinery => k8s.io/apimachinery v0.18.6
+	k8s.io/apiserver => k8s.io/apiserver v0.18.6
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.6
+	k8s.io/client-go => k8s.io/client-go v0.18.6
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.6
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.6
+	k8s.io/code-generator => k8s.io/code-generator v0.18.6
+	k8s.io/component-base => k8s.io/component-base v0.18.6
+	k8s.io/cri-api => k8s.io/cri-api v0.18.6
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.6
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.6
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.6
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.6
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.6
+	k8s.io/kubectl => k8s.io/kubectl v0.18.6
+	k8s.io/kubelet => k8s.io/kubelet v0.18.6
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.6
+	k8s.io/metrics => k8s.io/metrics v0.18.6
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.6
 )

--- a/go.mod
+++ b/go.mod
@@ -3,64 +3,64 @@ module github.com/weaveworks/cluster-api-provider-existinginfra
 go 1.13
 
 require (
-	github.com/bitnami-labs/sealed-secrets v0.12.5
-	github.com/blang/semver v3.5.1+incompatible
-	github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8
-	github.com/chanwit/plandiff v1.0.0
-	github.com/fatih/structs v1.1.0
-	github.com/ghodss/yaml v1.0.0
-	github.com/go-logr/logr v0.1.0
-	github.com/oleiade/reflections v1.0.0 // indirect
-	github.com/onsi/ginkgo v1.12.1
-	github.com/onsi/gomega v1.10.1
-	github.com/pkg/errors v0.9.1
-	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
-	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
-	github.com/sirupsen/logrus v1.6.0
-	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.6.1
-	github.com/tj/assert v0.0.3
-	github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e // indirect
-	github.com/weaveworks/libgitops v0.0.2
-	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
-	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-	gopkg.in/oleiade/reflections.v1 v1.0.0
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
-	k8s.io/api v0.18.6
-	k8s.io/apimachinery v0.18.8
-	k8s.io/client-go v0.18.6
-	k8s.io/cluster-bootstrap v0.18.6
-	k8s.io/kube-proxy v0.0.0
-	k8s.io/kubectl v0.18.6
-	k8s.io/kubernetes v1.18.6
-	k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
-	sigs.k8s.io/cluster-api v0.3.6
-	sigs.k8s.io/controller-runtime v0.6.0
-	sigs.k8s.io/kind v0.9.0 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.4.2
-	sigs.k8s.io/yaml v1.2.0
+    github.com/bitnami-labs/sealed-secrets v0.12.5
+    github.com/blang/semver v3.5.1+incompatible
+    github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8
+    github.com/chanwit/plandiff v1.0.0
+    github.com/fatih/structs v1.1.0
+    github.com/ghodss/yaml v1.0.0
+    github.com/go-logr/logr v0.1.0
+    github.com/oleiade/reflections v1.0.0 // indirect
+    github.com/onsi/ginkgo v1.12.1
+    github.com/onsi/gomega v1.10.1
+    github.com/pkg/errors v0.9.1
+    github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+    github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
+    github.com/sirupsen/logrus v1.6.0
+    github.com/spf13/pflag v1.0.5
+    github.com/stretchr/testify v1.6.1
+    github.com/tj/assert v0.0.3
+    github.com/weaveworks/footloose v0.0.0-20200918140536-ff126705213e // indirect
+    github.com/weaveworks/libgitops v0.0.2
+    golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
+    golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+    gopkg.in/oleiade/reflections.v1 v1.0.0
+    gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+    k8s.io/api v0.18.6
+    k8s.io/apimachinery v0.18.8
+    k8s.io/client-go v0.18.6
+    k8s.io/cluster-bootstrap v0.18.6
+    k8s.io/kube-proxy v0.0.0
+    k8s.io/kubectl v0.18.6
+    k8s.io/kubernetes v1.18.6
+    k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
+    sigs.k8s.io/cluster-api v0.3.6
+    sigs.k8s.io/controller-runtime v0.6.0
+    sigs.k8s.io/kind v0.9.0 // indirect
+    sigs.k8s.io/kustomize/kyaml v0.4.2
+    sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.18.6
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6
-	k8s.io/apimachinery => k8s.io/apimachinery v0.18.6
-	k8s.io/apiserver => k8s.io/apiserver v0.18.6
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.6
-	k8s.io/client-go => k8s.io/client-go v0.18.6
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.6
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.6
-	k8s.io/code-generator => k8s.io/code-generator v0.18.6
-	k8s.io/component-base => k8s.io/component-base v0.18.6
-	k8s.io/cri-api => k8s.io/cri-api v0.18.6
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.6
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.6
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.6
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.6
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.6
-	k8s.io/kubectl => k8s.io/kubectl v0.18.6
-	k8s.io/kubelet => k8s.io/kubelet v0.18.6
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.6
-	k8s.io/metrics => k8s.io/metrics v0.18.6
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.6
+    k8s.io/api => k8s.io/api v0.18.6
+    k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6
+    k8s.io/apimachinery => k8s.io/apimachinery v0.18.6
+    k8s.io/apiserver => k8s.io/apiserver v0.18.6
+    k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.6
+    k8s.io/client-go => k8s.io/client-go v0.18.6
+    k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.6
+    k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.6
+    k8s.io/code-generator => k8s.io/code-generator v0.18.6
+    k8s.io/component-base => k8s.io/component-base v0.18.6
+    k8s.io/cri-api => k8s.io/cri-api v0.18.6
+    k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.6
+    k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.6
+    k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.6
+    k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.6
+    k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.6
+    k8s.io/kubectl => k8s.io/kubectl v0.18.6
+    k8s.io/kubelet => k8s.io/kubelet v0.18.6
+    k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.6
+    k8s.io/metrics => k8s.io/metrics v0.18.6
+    k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.6
 )

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -215,7 +215,7 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 			"selinux:permissive",
 			&resource.Run{
 				Script:     object.String("setenforce 0 && sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config"),
-				UndoScript: object.String("setenforce 1 && sed -i 's/^SELINUX=permissive$/SELINUX=enforcing/' /etc/selinux/config"),
+				UndoScript: object.String("setenforce 1 && sed -i 's/^SELINUX=permissive$/SELINUX=enforcing/' /etc/selinux/config || true"),
 			})
 	}
 

--- a/pkg/utilities/envcfg/envcfg_test.go
+++ b/pkg/utilities/envcfg/envcfg_test.go
@@ -255,7 +255,7 @@ func TestGetEnvSpecificConfig(t *testing.T) {
 			},
 
 			wantUseIPTables:          true,
-			wantSetSELinuxPermissive: true,
+			wantSetSELinuxPermissive: false,
 			wantDisableSwap:          true,
 			wantLockYUMPkgs:          false,
 			wantNamespace:            "foo",

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -67,20 +67,20 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 	}
 
 	// If SELinux is Disabled skip setting it to permissive
-	skipSetSELinuxPermissive := false
+	// skipSetSELinuxPermissive := false
 	fmt.Println("Got SELinuxMode: ", seLinuxMode)
 	log.Info("Got SELinuxMode: ", seLinuxMode)
-	if seLinuxMode.IsDisabled() {
-		skipSetSELinuxPermissive = true
-	}
-	fmt.Println("Skip set selinux permissive: ", skipSetSELinuxPermissive)
-	log.Info("Skip set selinux permissive: ", skipSetSELinuxPermissive)
+	// if seLinuxMode.IsDisabled() {
+	// skipSetSELinuxPermissive = true
+	// }
+	// fmt.Println("Skip set selinux permissive: ", skipSetSELinuxPermissive)
+	// ("Skip set selinux permissive: ", skipSetSELinuxPermissive)
 
 	config := &EnvSpecificConfig{
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,
 		SELinuxInstalled:      seLinuxStatus.IsInstalled(),
-		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && seLinuxMode.IsEnforcing() && !skipSetSELinuxPermissive, // if selinux is installed, not disabled and not permissive, set it to permissive
+		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && !seLinuxMode.IsDisabled(), // if selinux is installed and not disabled, set it to permissive
 		LockYUMPkgs:           pkgType == resource.PkgTypeRPM,
 		DisableSwap:           !inContainerVM,
 		IgnorePreflightErrors: ignorePreflightErrors,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -2,7 +2,6 @@ package envcfg
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -66,16 +65,7 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 		}
 	}
 
-	// If SELinux is Disabled skip setting it to permissive
-	// skipSetSELinuxPermissive := false
-	fmt.Println("Got SELinuxMode: ", seLinuxMode)
-	log.Info("Got SELinuxMode: ", seLinuxMode)
-	// if seLinuxMode.IsDisabled() {
-	// skipSetSELinuxPermissive = true
-	// }
-	// fmt.Println("Skip set selinux permissive: ", skipSetSELinuxPermissive)
-	// ("Skip set selinux permissive: ", skipSetSELinuxPermissive)
-
+	log.Debug("Current SELinuxMode: ", seLinuxMode)
 	config := &EnvSpecificConfig{
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -2,6 +2,7 @@ package envcfg
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -67,10 +68,13 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 
 	// If SELinux is Disabled skip setting it to permissive
 	skipSetSELinuxPermissive := false
+	fmt.Println("Got SELinuxMode: ", seLinuxMode)
 	log.Info("Got SELinuxMode: ", seLinuxMode)
-	if seLinuxMode.IsDisabled() || seLinuxMode.IsPermissive() {
+	if seLinuxMode.IsDisabled() {
 		skipSetSELinuxPermissive = true
 	}
+	fmt.Println("Skip set selinux permissive: ", skipSetSELinuxPermissive)
+	log.Info("Skip set selinux permissive: ", skipSetSELinuxPermissive)
 
 	config := &EnvSpecificConfig{
 		ConntrackMax:          0,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -41,7 +41,7 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 	if err != nil {
 		return nil, errors.Wrap(err, "NewOS")
 	}
-	seLinuxStatus, _, err := osres.GetSELinuxStatus(ctx)
+	seLinuxStatus, seLinuxMode, err := osres.GetSELinuxStatus(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetSELinuxStatus")
 	}
@@ -65,11 +65,17 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 		}
 	}
 
+	// If SELinux is Disabled skip setting it to permissive
+	skipSetSELinuxPermissive := false
+	if seLinuxMode.IsDisabled() {
+		skipSetSELinuxPermissive = true
+	}
+
 	config := &EnvSpecificConfig{
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,
 		SELinuxInstalled:      seLinuxStatus.IsInstalled(),
-		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled(), // if selinux is installed always try to set to permissive
+		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && seLinuxMode.IsEnforcing() && !skipSetSELinuxPermissive, // if selinux is installed and not disabled, set it to permissive
 		LockYUMPkgs:           pkgType == resource.PkgTypeRPM,
 		DisableSwap:           !inContainerVM,
 		IgnorePreflightErrors: ignorePreflightErrors,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -67,9 +67,8 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 
 	// If SELinux is Disabled skip setting it to permissive
 	skipSetSELinuxPermissive := false
-	log.Info("Is SELinux disabled? ", seLinuxMode.IsDisabled())
-	log.Info("SELinuxMode: ", seLinuxMode)
-	if seLinuxMode.IsDisabled() {
+	log.Info("Got SELinuxMode: ", seLinuxMode)
+	if seLinuxMode.IsDisabled() || seLinuxMode.IsPermissive() {
 		skipSetSELinuxPermissive = true
 	}
 
@@ -77,7 +76,7 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 		ConntrackMax:          0,
 		UseIPTables:           !inContainerVM,
 		SELinuxInstalled:      seLinuxStatus.IsInstalled(),
-		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && seLinuxMode.IsEnforcing() && !skipSetSELinuxPermissive, // if selinux is installed and not disabled, set it to permissive
+		SetSELinuxPermissive:  !inContainerVM && seLinuxStatus.IsInstalled() && seLinuxMode.IsEnforcing() && !skipSetSELinuxPermissive, // if selinux is installed, not disabled and not permissive, set it to permissive
 		LockYUMPkgs:           pkgType == resource.PkgTypeRPM,
 		DisableSwap:           !inContainerVM,
 		IgnorePreflightErrors: ignorePreflightErrors,

--- a/pkg/utilities/envcfg/environment_config.go
+++ b/pkg/utilities/envcfg/environment_config.go
@@ -67,6 +67,8 @@ func GetEnvSpecificConfig(ctx context.Context, pkgType resource.PkgType, namespa
 
 	// If SELinux is Disabled skip setting it to permissive
 	skipSetSELinuxPermissive := false
+	log.Info("Is SELinux disabled? ", seLinuxMode.IsDisabled())
+	log.Info("SELinuxMode: ", seLinuxMode)
 	if seLinuxMode.IsDisabled() {
 		skipSetSELinuxPermissive = true
 	}

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "fix-selinux-permissive-undo-script-28adf0d6"
+const ImageTag = "fix-selinux-permissive-undo-script-df5d5d4b"

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "v0.0.9"
+const ImageTag = "fix-selinux-permissive-undo-script-3bc7a3a8"

--- a/pkg/utilities/version/generated.go
+++ b/pkg/utilities/version/generated.go
@@ -1,3 +1,3 @@
 package version
 
-const ImageTag = "fix-selinux-permissive-undo-script-3bc7a3a8"
+const ImageTag = "fix-selinux-permissive-undo-script-28adf0d6"


### PR DESCRIPTION
- Adds `|| true` in the undoScript of `selinux:permissive`.
- Reads `SELinuxMode` from OS that was removed in https://github.com/weaveworks/cluster-api-provider-existinginfra/commit/cc19d69abae89a4b1d42b2758c272dfdd4e60ff0
  and adds it as a parameter in the condition to set selinux to permissive, and skip if it is disabled.
- Adds check to skip repaving of the original control plane node, if there is a diff in the plan and there is no control plane load balancer set.