### PR TITLE
Drain: allow pods grace period to terminate

### DIFF
--- a/pkg/kubernetes/drain/facade.go
+++ b/pkg/kubernetes/drain/facade.go
@@ -30,6 +30,7 @@ func Drain(node *corev1.Node, clientSet kubernetes.Interface, params Params) err
 	defer drainLog.Close()
 	drainer := &drain.Helper{
 		Client:              clientSet,
+		GracePeriodSeconds:  -1,
 		Force:               params.Force,
 		DeleteLocalData:     params.DeleteLocalData,
 		IgnoreAllDaemonSets: params.IgnoreAllDaemonSets,


### PR DESCRIPTION
The default of 0 is taken as "delete immediately", which is not appropriate.

Fixes #47 
