### PR TITLE
[WKP-1054] Disable swap at cluster creation time persistently

### DIFF
--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -352,7 +352,7 @@ func buildDisableSwapPlan() plan.Resource {
 			// The ";" instead of "&&" below is because we want to copy the empty temp file over /etc/fstab if /etc/fstab only contains swap entries
 			// and the "egrep" will fail on an empty file
 			`tmpfile=$(mktemp /tmp/disable-swap.XXXXXX) && egrep -v '\s*\S*\s*\S*\s*swap.*' /etc/fstab > $tmpfile; mv $tmpfile /etc/fstab`)},
-		plan.DependOn("configure:discable-swap-in-session"))
+		plan.DependOn("configure:disable-swap-in-session"))
 	p, err := b.Plan()
 	if err != nil {
 		log.Fatalf("%v", err)

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -279,7 +279,7 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 			kubeletDeps = append(kubeletDeps, swapDisable)
 			b.AddResource(
 				swapDisable,
-				&resource.Run{Script: object.String("/sbin/swapoff -a")},
+				buildDisableSwapPlan(),
 				plan.DependOn("create-dir:kubelet.service.d"))
 			kubeletSysconfig := "configure:kubelet-sysconfig"
 			b.AddResource(
@@ -305,7 +305,7 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 			kubeletDeps = append(kubeletDeps, swapDisable)
 			b.AddResource(
 				swapDisable,
-				&resource.Run{Script: object.String("/sbin/swapoff -a")},
+				buildDisableSwapPlan(),
 				plan.DependOn("create-dir:kubelet.service.d"))
 			kubeletDefault := "configure:kubelet-default"
 			kubeletDeps = append(kubeletDeps, kubeletDefault)
@@ -335,6 +335,21 @@ func BuildK8SPlan(kubernetesVersion string, kubeletNodeIP string, seLinuxInstall
 		"service-init:kubelet",
 		&resource.Service{Name: "kubelet", Status: "active", Enabled: true},
 		plan.DependOn("systemd:daemon-reload", kubeletDeps...))
+	p, err := b.Plan()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	return &p
+}
+
+// BuildDisableSwapPlan turns off swap and removes swap entries from /etc/fstab so swap will remain disabled on reboot
+func buildDisableSwapPlan() plan.Resource {
+	b := plan.NewBuilder()
+	b.AddResource("configure:disable-swap-in-session", &resource.Run{Script: object.String("/sbin/swapoff -a")})
+	b.AddResource(
+		"configure:disable-swap-going-forward",
+		&resource.Run{Script: object.String(`tmpfile=$(mktemp /tmp/abc-script.XXXXXX) && egrep -v '\s*\S*\s*\S*\s*swap.*' /etc/fstab > $tmpfile && mv $tmpfile /etc/fstab`)},
+		plan.DependOn("configure:discable-swap-in-session"))
 	p, err := b.Plan()
 	if err != nil {
 		log.Fatalf("%v", err)

--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -348,7 +348,10 @@ func buildDisableSwapPlan() plan.Resource {
 	b.AddResource("configure:disable-swap-in-session", &resource.Run{Script: object.String("/sbin/swapoff -a")})
 	b.AddResource(
 		"configure:disable-swap-going-forward",
-		&resource.Run{Script: object.String(`tmpfile=$(mktemp /tmp/abc-script.XXXXXX) && egrep -v '\s*\S*\s*\S*\s*swap.*' /etc/fstab > $tmpfile && mv $tmpfile /etc/fstab`)},
+		&resource.Run{Script: object.String(
+			// The ";" instead of "&&" below is because we want to copy the empty temp file over /etc/fstab if /etc/fstab only contains swap entries
+			// and the "egrep" will fail on an empty file
+			`tmpfile=$(mktemp /tmp/disable-swap.XXXXXX) && egrep -v '\s*\S*\s*\S*\s*swap.*' /etc/fstab > $tmpfile; mv $tmpfile /etc/fstab`)},
 		plan.DependOn("configure:discable-swap-in-session"))
 	p, err := b.Plan()
 	if err != nil {

--- a/test/integration/test/workload_cluster_test.go
+++ b/test/integration/test/workload_cluster_test.go
@@ -283,7 +283,6 @@ func seedNodeAction(c *testContext, cmd string) {
 func ensureSwapSettingsArePersisted(c *testContext) {
 	swapdata, _, err := seedNodeCall(c, "swapon --show --noheadings | cut -f1 -d' '")
 	require.NoError(c.t, err)
-	lines := ""
 
 	if len(swapdata) == 0 {
 		seedNodeAction(c, "dd if=/dev/zero of=/swapfile bs=1024 count=1048576")
@@ -291,9 +290,8 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 		seedNodeAction(c, "mkswap /swapfile")
 		seedNodeAction(c, "swapon /swapfile")
 		seedNodeAction(c, "echo /swapfile swap swap defaults 0 0 > /etc/fstab")
-		fmt.Printf("FSTAB:\n")
-		seedNodeAction(c, "cat /etc/fstab")
 	} else {
+		lines := ""
 		swaplines := strings.Split(string(swapdata), "\n")
 		fstabdata, _, err := seedNodeCall(c, "cat /etc/fstab | cut -f1 -d' '")
 		require.NoError(c.t, err)
@@ -316,8 +314,8 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 				lines = lines + fmt.Sprintf("%s swap swap defaults 0 0\n", swapname)
 			}
 		}
+		seedNodeAction(c, fmt.Sprintf("echo '%s' >> /etc/fstab", lines))
 	}
-	seedNodeAction(c, fmt.Sprintf("echo '%s' >> /etc/fstab", lines))
 }
 
 // Check that swap stays off after a reboot

--- a/test/integration/test/workload_cluster_test.go
+++ b/test/integration/test/workload_cluster_test.go
@@ -281,6 +281,7 @@ func seedNodeAction(c *testContext, cmd string) {
 
 // Set up fstab so swap settings are persisted (so we can test unsetting them)
 func ensureSwapSettingsArePersisted(c *testContext) {
+	log.Info("Storing persistent swap settings to later be disabled...")
 	swapdata, _, err := seedNodeCall(c, "swapon --show --noheadings | cut -f1 -d' '")
 	require.NoError(c.t, err)
 
@@ -313,6 +314,7 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 
 // Check that swap stays off after a reboot
 func ensureSwapShutdownPersists(c *testContext) {
+	log.Info("Ensuring persistent swap settings were removed during cluster creation...")
 	swapdata, _, err := seedNodeCall(c, "swapon --show --noheadings | cut -f1 -d' '")
 	require.NoError(c.t, err)
 	require.Equal(c.t, string(swapdata), "")

--- a/test/integration/test/workload_cluster_test.go
+++ b/test/integration/test/workload_cluster_test.go
@@ -121,6 +121,9 @@ func TestWorkloadClusterCreation(t *testing.T) {
 	// Wait for the management cluster to be ready
 	ensureAllManagementPodsAreRunning(c)
 
+	// Store swap settings in /etc/fstab so we can demonstrate they are removed
+	ensureSwapSettingsArePersisted(c)
+
 	// Create a workload cluster
 	createWorkloadCluster(c, version)
 

--- a/test/integration/test/workload_cluster_test.go
+++ b/test/integration/test/workload_cluster_test.go
@@ -285,6 +285,8 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 	fstablines := strings.Split(string(fstabdata), "\n")
 	require.NoError(c.t, err)
 
+	fmt.Printf("SWAPLINES: %s\nFSTABLINES: %s\n", swaplines, fstablines)
+
 	lines := ""
 	for _, line := range swaplines {
 		found := false
@@ -301,7 +303,6 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 		}
 	}
 
-	fmt.Printf("LINES: %s\n", lines)
 	seedNodeCall(c, fmt.Sprintf("echo '%s' >> /etc/fstab", lines))
 }
 
@@ -309,7 +310,7 @@ func ensureSwapSettingsArePersisted(c *testContext) {
 func ensureSwapShutdownPersists(c *testContext) {
 	swapdata, _, err := seedNodeCall(c, "swapon --show --noheadings | cut -f1 -d' '")
 	require.NoError(c.t, err)
-	require.Equal(c.t, swapdata, "")
+	require.Equal(c.t, string(swapdata), "")
 }
 
 // Wait for the management cluster to be ready for cluster creation


### PR DESCRIPTION
Prior to this PR, we turned swap off during cluster installation via `swapoff -a`. This works, but if swap entries are present in /etc/fstab, they will be re-enabled on reboot. This change removes swap entries from /etc/fstab as well.