### PR TITLE
Fix Kubelet argument processing for RPM-based clusters

### DIFF
--- a/pkg/plan/recipe/install_plans.go
+++ b/pkg/plan/recipe/install_plans.go
@@ -347,7 +347,7 @@ ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELE
 				kubeletSysconfig,
 				&resource.File{
 					Content:     processAdditionalArgs(fmt.Sprintf("KUBELET_EXTRA_ARGS=--node-ip=%s", kubeletNodeIP)),
-					Destination: "/etc/sysconfig/kubelet"},
+					Destination: "/etc/default/kubelet"},
 				plan.DependOn("create-dir:kubelet.service.d", "install:kubelet"))
 			kubeletDeps = append(kubeletDeps, kubeletSysconfig)
 		} else {
@@ -357,7 +357,7 @@ ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELE
 				kubeletSysconfig,
 				&resource.File{
 					Content:     processAdditionalArgs(fmt.Sprintf("KUBELET_EXTRA_ARGS=--fail-swap-on=false --node-ip=%s", kubeletNodeIP)),
-					Destination: "/etc/sysconfig/kubelet"},
+					Destination: "/etc/default/kubelet"},
 				plan.DependOn("create-dir:kubelet.service.d", "install:kubelet"))
 		}
 	case resource.PkgTypeDeb:

--- a/test/integration/test/test_tools.go
+++ b/test/integration/test/test_tools.go
@@ -247,6 +247,7 @@ func (c *testContext) makeSSHCallWithRetries(ip, port, cmd string, retryCount in
 			return
 		}
 		log.Infof("Call '%s' failed: %s, %s, %v", cmd, out, eout, err)
+		time.Sleep(30 * time.Second)
 	}
 	require.FailNow(c.t, fmt.Sprintf("SSH call failed all retries"))
 }

--- a/test/integration/test/test_tools.go
+++ b/test/integration/test/test_tools.go
@@ -248,6 +248,7 @@ func (c *testContext) makeSSHCallWithRetries(ip, port, cmd string, retryCount in
 		}
 		log.Infof("Call '%s' failed: %s, %s, %v", cmd, out, eout, err)
 	}
+	require.FailNow(c.t, fmt.Sprintf("SSH call failed all retries"))
 }
 
 // Check that a specified number of a resource type is running


### PR DESCRIPTION
A new service configuration was added to kubelet in support of eks-d. Prior to this, we stored kubelet args in the default location for each OS (/etc/sysconfig/kubelet for CentOS/RHEL, /etc/default/kubelet for DEB). The new configuration defines the kubelet arg file as /etc/default/kubelet but we were still storing the args in /etc/sysconfig/kubelet for RPM-based system.