### PR TITLE
Fix integration tests: set haproxy version to 2.3

### DIFF
--- a/test/integration/test/test_tools.go
+++ b/test/integration/test/test_tools.go
@@ -402,7 +402,7 @@ func (c *testContext) ConfigureHAProxy(loadBalancerAddress string, loadBalancerS
 		Destination: "/tmp/haproxy.cfg",
 	}
 	haproxyResource := &resource.Run{
-		Script:     object.String("mkdir /tmp/haproxy && docker run --detach --name haproxy -v /tmp/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg -v /tmp/haproxy:/var/lib/haproxy -p 6443:6443 haproxy"),
+		Script:     object.String("mkdir /tmp/haproxy && docker run --detach --name haproxy -v /tmp/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg -v /tmp/haproxy:/var/lib/haproxy -p 6443:6443 haproxy:2.3"),
 		UndoScript: object.String("docker rm haproxy || true"),
 	}
 	lbPlanBuilder := plan.NewBuilder()


### PR DESCRIPTION
When https://github.com/docker-library/haproxy/pull/157 landed, 2.4 became the new default/`latest` image and we started seeing this error:

```
$ sudo docker logs d45e66cf1b2e
[NOTICE]   (1) : haproxy version is 2.4.0-6cbbecf
[NOTICE]   (1) : path to executable is /usr/local/sbin/haproxy
[ALERT]    (1) : Could not open configuration file /usr/local/etc/haproxy/haproxy.cfg : Permission denied
```

We have a unpinned haproxy image, this pins it to 2.3 for now which fixes things for now. We should look into this at some point so we can keep up w/ haproxy.